### PR TITLE
Add patient search and main menu forms

### DIFF
--- a/HuellaHID/Forms/BuscarForm.cs
+++ b/HuellaHID/Forms/BuscarForm.cs
@@ -1,0 +1,107 @@
+using DPFP;
+using DPFP.Capture;
+using DPFP.Processing;
+using HuellaHID.Models;
+using HuellaHID.Services;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace HuellaHID.Forms
+{
+    // Formulario para capturar una huella y buscar al paciente en la base de datos
+    public class BuscarForm : Form, DPFP.Capture.EventHandler
+    {
+        private Label lblInfo;
+        private Capture capturador;
+        private Verification verificator;
+        private List<PatientFingerprint> huellas;
+
+        public BuscarForm()
+        {
+            Text = "Buscar Paciente";
+            Width = 300;
+            Height = 120;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            StartPosition = FormStartPosition.CenterScreen;
+            BackColor = Color.AliceBlue;
+            Font = new Font("Segoe UI", 9F);
+            lblInfo = new Label
+            {
+                Text = "Coloque su huella para buscar",
+                AutoSize = true,
+                Left = 20,
+                Top = 20,
+                ForeColor = Color.Navy
+            };
+            Controls.Add(lblInfo);
+
+            Load += async (s, e) => await InicializarAsync();
+        }
+
+        private async Task InicializarAsync()
+        {
+            huellas = await DatabaseService.ObtenerHuellasAsync();
+            verificator = new Verification();
+
+            capturador = new Capture();
+            if (capturador != null)
+            {
+                capturador.EventHandler = this;
+                capturador.StartCapture();
+            }
+            else
+            {
+                MessageBox.Show("No se pudo iniciar el lector");
+            }
+        }
+
+        public void OnComplete(object Capture, string ReaderSerialNumber, Sample sample)
+        {
+            var features = ExtraerCaracteristicas(sample, DataPurpose.Verification);
+            if (features == null) return;
+
+            foreach (var h in huellas)
+            {
+                var template = new Template();
+                using (var ms = new MemoryStream(h.TemplateBytes))
+                {
+                    template.Deserialize(ms);
+                }
+                var result = new Verification.Result();
+                verificator.Verify(features, template, ref result);
+                if (result.Verified)
+                {
+                    capturador.StopCapture();
+                    BeginInvoke(new Action(async () =>
+                    {
+                        lblInfo.Text = $"Paciente encontrado: {h.Nombre} (ID: {h.PacienteId})";
+                        await ApiService.EnviarResultadoAsync(h.PacienteId);
+                    }));
+                    return;
+                }
+            }
+
+            BeginInvoke(new Action(() => { lblInfo.Text = "Paciente no encontrado"; }));
+        }
+
+        public void OnFingerGone(object Capture, string ReaderSerialNumber) { }
+        public void OnFingerTouch(object Capture, string ReaderSerialNumber) { }
+        public void OnReaderConnect(object Capture, string ReaderSerialNumber) { }
+        public void OnReaderDisconnect(object Capture, string ReaderSerialNumber) { }
+        public void OnSampleQuality(object Capture, string ReaderSerialNumber, CaptureFeedback CaptureFeedback) { }
+
+        private FeatureSet ExtraerCaracteristicas(Sample sample, DataPurpose purpose)
+        {
+            var extractor = new FeatureExtraction();
+            var feedback = CaptureFeedback.None;
+            var features = new FeatureSet();
+            extractor.CreateFeatureSet(sample, purpose, ref feedback, ref features);
+            return feedback == CaptureFeedback.Good ? features : null;
+        }
+    }
+}

--- a/HuellaHID/Forms/Form1.Designer.cs
+++ b/HuellaHID/Forms/Form1.Designer.cs
@@ -70,31 +70,44 @@
             this.cmbDedo.Size = new System.Drawing.Size(150, 21);
 
             // btnIniciarCaptura
+            this.btnIniciarCaptura.BackColor = System.Drawing.Color.RoyalBlue;
+            this.btnIniciarCaptura.FlatAppearance.BorderSize = 0;
+            this.btnIniciarCaptura.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnIniciarCaptura.ForeColor = System.Drawing.Color.White;
             this.btnIniciarCaptura.Location = new System.Drawing.Point(30, 140);
             this.btnIniciarCaptura.Name = "btnIniciarCaptura";
             this.btnIniciarCaptura.Size = new System.Drawing.Size(240, 30);
             this.btnIniciarCaptura.Text = "Iniciar Captura de Huella";
-            this.btnIniciarCaptura.UseVisualStyleBackColor = true;
+            this.btnIniciarCaptura.UseVisualStyleBackColor = false;
             this.btnIniciarCaptura.Click += new System.EventHandler(this.btnIniciarCaptura_Click);
 
             // btnEnviarHuella
+            this.btnEnviarHuella.BackColor = System.Drawing.Color.RoyalBlue;
+            this.btnEnviarHuella.FlatAppearance.BorderSize = 0;
+            this.btnEnviarHuella.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnEnviarHuella.ForeColor = System.Drawing.Color.White;
             this.btnEnviarHuella.Location = new System.Drawing.Point(30, 180);
             this.btnEnviarHuella.Name = "btnEnviarHuella";
             this.btnEnviarHuella.Size = new System.Drawing.Size(240, 30);
             this.btnEnviarHuella.Text = "Enviar Huella";
-            this.btnEnviarHuella.UseVisualStyleBackColor = true;
+            this.btnEnviarHuella.UseVisualStyleBackColor = false;
             this.btnEnviarHuella.Enabled = false;
             this.btnEnviarHuella.Click += new System.EventHandler(this.btnEnviarHuella_Click);
 
             // lblEstado
             this.lblEstado.AutoSize = true;
+            this.lblEstado.ForeColor = System.Drawing.Color.Navy;
             this.lblEstado.Location = new System.Drawing.Point(30, 220);
             this.lblEstado.Name = "lblEstado";
             this.lblEstado.Size = new System.Drawing.Size(120, 13);
             this.lblEstado.Text = "Estado del lector huella.";
 
             // Form1
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.BackColor = System.Drawing.Color.AliceBlue;
             this.ClientSize = new System.Drawing.Size(300, 260);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.Controls.Add(this.lblPacienteId);
             this.Controls.Add(this.txtPacienteId);
             this.Controls.Add(this.lblMano);

--- a/HuellaHID/Forms/Form1.cs
+++ b/HuellaHID/Forms/Form1.cs
@@ -6,6 +6,7 @@ using HuellaHID.Models;
 using HuellaHID.Services;
 using System;
 using System.IO;
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace HuellaHID.Forms
@@ -112,9 +113,15 @@ namespace HuellaHID.Forms
             };
 
             btnEnviarHuella.Enabled = false;
-            lblEstado.Text = "Enviando huella...";
-            bool result = await ApiService.EnviarHuellaAsync(request);
-            lblEstado.Text = result ? "Huella registrada correctamente" : "Error al registrar huella";
+            lblEstado.Text = "Guardando huella...";
+
+            bool dbOk = await DatabaseService.GuardarHuellaAsync(pacienteid, mano, dedo, bytes);
+            bool apiOk = await ApiService.EnviarHuellaAsync(request);
+
+            if (dbOk && apiOk)
+                lblEstado.Text = "Huella registrada correctamente";
+            else
+                lblEstado.Text = "Error al registrar huella";
         }
 
         private void btnIniciarCaptura_Click(object sender, EventArgs e)

--- a/HuellaHID/Forms/MainForm.cs
+++ b/HuellaHID/Forms/MainForm.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace HuellaHID.Forms
+{
+    // Ventana principal con opciones de registro y búsqueda
+    public class MainForm : Form
+    {
+        private Button btnRegistrar;
+        private Button btnBuscar;
+
+        public MainForm()
+        {
+            Text = "Huella HID";
+            Width = 250;
+            Height = 150;
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            StartPosition = FormStartPosition.CenterScreen;
+            BackColor = Color.AliceBlue;
+            Font = new Font("Segoe UI", 9F);
+
+            btnRegistrar = new Button
+            {
+                Text = "Registrar Paciente",
+                Left = 30,
+                Top = 20,
+                Width = 180,
+                BackColor = Color.RoyalBlue,
+                ForeColor = Color.White,
+                FlatStyle = FlatStyle.Flat,
+            };
+            btnRegistrar.FlatAppearance.BorderSize = 0;
+
+            btnBuscar = new Button
+            {
+                Text = "Buscar Paciente",
+                Left = 30,
+                Top = 60,
+                Width = 180,
+                BackColor = Color.RoyalBlue,
+                ForeColor = Color.White,
+                FlatStyle = FlatStyle.Flat,
+            };
+            btnBuscar.FlatAppearance.BorderSize = 0;
+
+            btnRegistrar.Click += (s, e) =>
+            {
+                using (var f = new Form1())
+                {
+                    f.ShowDialog();
+                }
+            };
+
+            btnBuscar.Click += (s, e) =>
+            {
+                using (var f = new BuscarForm())
+                {
+                    f.ShowDialog();
+                }
+            };
+
+            Controls.Add(btnRegistrar);
+            Controls.Add(btnBuscar);
+        }
+    }
+}

--- a/HuellaHID/HuellaHID.csproj
+++ b/HuellaHID/HuellaHID.csproj
@@ -126,10 +126,15 @@
     <Compile Include="Forms\Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="Forms\MainForm.cs" />
+    <Compile Include="Forms\BuscarForm.cs" />
     <Compile Include="Models\HuellaRequest.cs" />
+    <Compile Include="Models\ResultadoRequest.cs" />
+    <Compile Include="Models\PatientFingerprint.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\ApiService.cs" />
+    <Compile Include="Services\DatabaseService.cs" />
     <EmbeddedResource Include="Forms\Form1.resx">
       <DependentUpon>Form1.cs</DependentUpon>
     </EmbeddedResource>

--- a/HuellaHID/Models/PatientFingerprint.cs
+++ b/HuellaHID/Models/PatientFingerprint.cs
@@ -1,0 +1,12 @@
+namespace HuellaHID.Models
+{
+    // Representa una huella almacenada en la base de datos
+    public class PatientFingerprint
+    {
+        public int PacienteId { get; set; }
+        public string Nombre { get; set; }
+        public string Mano { get; set; }
+        public string Dedo { get; set; }
+        public byte[] TemplateBytes { get; set; }
+    }
+}

--- a/HuellaHID/Models/ResultadoRequest.cs
+++ b/HuellaHID/Models/ResultadoRequest.cs
@@ -1,0 +1,8 @@
+namespace HuellaHID.Models
+{
+    // Modelo usado para enviar el resultado de una búsqueda al backend
+    public class ResultadoRequest
+    {
+        public int paciente_id { get; set; }
+    }
+}

--- a/HuellaHID/Program.cs
+++ b/HuellaHID/Program.cs
@@ -12,14 +12,16 @@ namespace HuellaHID.Forms
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
-            var form = new Form1();
-
             if (args.Length > 0 && int.TryParse(args[0], out int pacienteId))
             {
+                var form = new Form1();
                 form.SetPacienteId(pacienteId);
+                Application.Run(form);
             }
-
-            Application.Run(form);
+            else
+            {
+                Application.Run(new MainForm());
+            }
         }
     }
 }

--- a/HuellaHID/Services/ApiService.cs
+++ b/HuellaHID/Services/ApiService.cs
@@ -19,31 +19,45 @@ namespace HuellaHID.Services
                 string url = "http://127.0.0.1:8000/admin/api/registrar-huella/";
                 var json = JsonConvert.SerializeObject(data);
 
-                // Mostrar el JSON que se envía (para debug)
-                MessageBox.Show("📤 Enviando JSON:\n" + json);
-
                 var content = new StringContent(json, Encoding.UTF8, "application/json");
                 var response = await client.PostAsync(url, content);
 
-                var respStr = await response.Content.ReadAsStringAsync();
-
-                // Mostrar código de estado y respuesta completa
-                MessageBox.Show($"🔍 Status: {(int)response.StatusCode}\nRespuesta:\n{respStr}");
-
-                if (response.IsSuccessStatusCode)
-                {
-                    MessageBox.Show("✅ Huella registrada correctamente.");
-                    return true;
-                }
-                else
-                {
-                    MessageBox.Show($"❌ Error al registrar huella ({(int)response.StatusCode}).");
-                    return false;
-                }
+                return response.IsSuccessStatusCode;
+            }
+            catch (HttpRequestException ex)
+            {
+                MessageBox.Show("Servidor no disponible: " + ex.Message);
+                return false;
             }
             catch (Exception ex)
             {
-                MessageBox.Show("❌ Error de red: " + ex.Message);
+                MessageBox.Show("Error al enviar huella: " + ex.Message);
+                return false;
+            }
+        }
+
+        // Envía el paciente encontrado al backend
+        public static async Task<bool> EnviarResultadoAsync(int pacienteId)
+        {
+            try
+            {
+                string url = "http://localhost:8000/api/biometrico/resultado/";
+                var obj = new ResultadoRequest { paciente_id = pacienteId };
+                var json = JsonConvert.SerializeObject(obj);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                var response = await client.PostAsync(url, content);
+
+                return response.IsSuccessStatusCode;
+            }
+            catch (HttpRequestException ex)
+            {
+                MessageBox.Show("Servidor no disponible: " + ex.Message);
+                return false;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error enviando resultado: " + ex.Message);
                 return false;
             }
         }

--- a/HuellaHID/Services/DatabaseService.cs
+++ b/HuellaHID/Services/DatabaseService.cs
@@ -1,0 +1,65 @@
+using HuellaHID.Models;
+using Npgsql;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace HuellaHID.Services
+{
+    // Servicio para guardar y obtener huellas desde PostgreSQL
+    public static class DatabaseService
+    {
+        private static readonly string connectionString = ConfigurationManager.ConnectionStrings["PostgresConnection"].ConnectionString;
+
+        public static async Task<bool> GuardarHuellaAsync(int pacienteId, string mano, string dedo, byte[] templateBytes)
+        {
+            try
+            {
+                using var conn = new NpgsqlConnection(connectionString);
+                await conn.OpenAsync();
+                using var cmd = new NpgsqlCommand("INSERT INTO huellas(paciente_id, mano, dedo, template) VALUES (@p1,@p2,@p3,@p4)", conn);
+                cmd.Parameters.AddWithValue("@p1", pacienteId);
+                cmd.Parameters.AddWithValue("@p2", mano);
+                cmd.Parameters.AddWithValue("@p3", dedo);
+                cmd.Parameters.AddWithValue("@p4", templateBytes);
+                await cmd.ExecuteNonQueryAsync();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error al guardar en la base de datos: " + ex.Message);
+                return false;
+            }
+        }
+
+        public static async Task<List<PatientFingerprint>> ObtenerHuellasAsync()
+        {
+            var list = new List<PatientFingerprint>();
+            try
+            {
+                using var conn = new NpgsqlConnection(connectionString);
+                await conn.OpenAsync();
+                using var cmd = new NpgsqlCommand("SELECT h.paciente_id, p.nombre, h.mano, h.dedo, h.template FROM huellas h JOIN pacientes p ON p.id = h.paciente_id", conn);
+                using var reader = await cmd.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    list.Add(new PatientFingerprint
+                    {
+                        PacienteId = reader.GetInt32(0),
+                        Nombre = reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+                        Mano = reader.GetString(2),
+                        Dedo = reader.GetString(3),
+                        TemplateBytes = (byte[])reader[4]
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error al obtener huellas: " + ex.Message);
+            }
+            return list;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add initial MainForm with "Registrar" and "Buscar" options
- implement BuscarForm for fingerprint lookup and API result reporting
- store and read fingerprints via new DatabaseService
- extend ApiService with result endpoint and error handling
- update registration form to persist to the database
- show MainForm on startup when no arguments are given
- apply blue clinic UI theme across forms

## Testing
- `msbuild HuellaHID.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68523df67b14832da63bc321d8c3ea04